### PR TITLE
Use py and static bat for windows

### DIFF
--- a/build/windows/uget-chrome-wrapper.nsi
+++ b/build/windows/uget-chrome-wrapper.nsi
@@ -156,10 +156,8 @@ Section "uget-chrome-wrapper (required)"
 	; Replace \ by \\ in the installation path
 	${StrRep} $0 "$INSTDIR" "\" "\\"
 	
-	; Create the uget-chrome-wrapper.bat file
-	FileOpen $9 $INSTDIR\uget-chrome-wrapper.bat w ;Opens a Empty File an fills it
-	FileWrite $9 '@echo off$\r$\ncall python "$0\\uget-chrome-wrapper.py"$\r$\n'
-	FileClose $9 ;Closes the filled file
+	; Put the uget-chrome-wrapper.bat file
+	File "..\..\uget-chrome-wrapper\windows\uget-chrome-wrapper.bat"
 
 	; Update the com.javahelps.ugetchromewrapper.json file
 	FileOpen $9 $INSTDIR\com.javahelps.ugetchromewrapper.json w ;Opens a Empty File an fills it

--- a/uget-chrome-wrapper/windows/uget-chrome-wrapper.bat
+++ b/uget-chrome-wrapper/windows/uget-chrome-wrapper.bat
@@ -1,0 +1,2 @@
+@echo off
+py "%~dp0uget-chrome-wrapper.py"


### PR DESCRIPTION
Currently, the windows installation
* Writes the installation path into `uget-chrome-wrapper.bat` dynamically
* Calls `python`

But
* We can eliminate the need to write the full path, using [`%~dp0`](https://stackoverflow.com/a/27122098).
* [`py` is the preferred launcher](http://learning-python.com/py33-windows-launcher.html) on Python 3.3+ for Windows. Using `py` also eliminates the need to add Python to `PATH` environment variable mentioned in [the installation instruction](https://slgobinath.github.io/uget-chrome-wrapper/#windows).

So here it is.
