### PR TITLE
Provide subprocess with creationflags on Windows

### DIFF
--- a/uget-chrome-wrapper/bin/uget-chrome-wrapper
+++ b/uget-chrome-wrapper/bin/uget-chrome-wrapper
@@ -37,6 +37,7 @@ cookie_filepath = join(tempfile.gettempdir(), 'uget_cookie')
 urls_filepath = join(tempfile.gettempdir(), 'uget_urls')
 UGET_COMMAND = "uget-gtk"
 VERSION = "2.0.7"
+creation_flags = 0
 
 logger = logging.getLogger()
 # log_file_path = join(expanduser('~'), 'uget-chrome-wrapper.log')
@@ -51,6 +52,8 @@ if sys.platform == 'win32':
     msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
     msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
     UGET_COMMAND = 'uget'
+    # CREATE_BREAKAWAY_FROM_JOB
+    creation_flags |= 0x01000000
 
 
 def extract_file_name(url):
@@ -208,7 +211,7 @@ def read_message():
 
                 logger.debug('Execute command: ' + str(command))
                 # Pass the parameters to uGet
-                subprocess.call(command)
+                subprocess.Popen(command, creationflags=creation_flags).wait()
 
                 if use_cookie_file:
                     try:


### PR DESCRIPTION
On Windows, Firefox puts the native application process (and effectively its child processes by default) into a job object. After the native application responds, Firefox kills all the processes in the job object including the uGet process launched by *uget-chrome-wrapper*. See [the documentation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app).

So on Windows Firefox in many cases the uGet is killed as soon as launched.

This PR sets the process flag `CREATE_BREAKAWAY_FROM_JOB` on Windows so that the uGet process is created out of the job object and not killed together.

The flag constant is exposed on [Python 3.7](https://docs.python.org/3.7/library/subprocess.html#subprocess.CREATE_BREAKAWAY_FROM_JOB) which is too new. So this PR uses the raw numeric value instead.
